### PR TITLE
Fix compilation with newer gcc and clang versions

### DIFF
--- a/src/Vector/BLF/platform.h
+++ b/src/Vector/BLF/platform.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <Vector/BLF/config.h>
+#include <cstdint>
 
 /* GCC */
 #ifdef __GNUC__


### PR DESCRIPTION
GCC > 12 and CLANG > 15 (?) fails to compile code due to missing std int types:

error: unknown type name 'uint32_t'