### PR TITLE
Disable tests and docs addition to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ project(Vector_BLF
     DESCRIPTION "Vector Binary Log File support library")
 
 # source code documentation
-option(OPTION_RUN_DOXYGEN "Run Doxygen" ON)
+option(OPTION_RUN_DOXYGEN "Run Doxygen" OFF)
 
 # static code analysis
 option(OPTION_RUN_CCCC "Run CCCC" OFF)

--- a/src/Vector/BLF/CMakeLists.txt
+++ b/src/Vector/BLF/CMakeLists.txt
@@ -356,5 +356,10 @@ if (NOT FETCH_CONTENT_INCLUSION)
 endif()
 
 # sub directories
-add_subdirectory(docs)
-add_subdirectory(tests)
+if (OPTION_RUN_DOXYGEN)
+    add_subdirectory(docs)
+endif()
+
+if (OPTION_BUILD_TESTS)
+    add_subdirectory(tests)
+endif()


### PR DESCRIPTION
Needed to disable the addition of the tests and docs subdirs to the cmake build. Also disabeled docs generation by default